### PR TITLE
Refactor ISerializable to serialize into cJSON pointers

### DIFF
--- a/cpp/components/ISerializable/CMakeLists.txt
+++ b/cpp/components/ISerializable/CMakeLists.txt
@@ -1,4 +1,4 @@
 idf_component_register(
-    SRCS "ISerializable.cpp"
     INCLUDE_DIRS "include"
+    REQUIRES "json"
 )

--- a/cpp/components/ISerializable/ISerializable.cpp
+++ b/cpp/components/ISerializable/ISerializable.cpp
@@ -1,7 +1,0 @@
-#include <stdio.h>
-#include "ISerializable.h"
-
-void func(void)
-{
-
-}

--- a/cpp/components/ISerializable/include/ISerializable.h
+++ b/cpp/components/ISerializable/include/ISerializable.h
@@ -1,13 +1,31 @@
-#ifndef ISERIALIZABLE_H
-#define ISERIALIZABLE_H
+#pragma once
 
 #include <string>
+#include <memory>
+#include "cJSON.h"
 
-using namespace std;
+class ISerializable
+{
+public:
+    /**
+     * @brief Serialize the object to a cJSON object
+     *
+     * @return std::unique_ptr<cJSON, void (*)(cJSON *item)> The serialized cJSON object
+     */
+    virtual std::unique_ptr<cJSON, void (*)(cJSON *item)> serialize() = 0;
 
-class ISerializable {
-    public:
-        virtual string serialize() = 0;
+    /**
+     * @brief Serialize the object to a string
+     *
+     * @param pretty Whether to pretty-print the JSON
+     * @return string The serialized JSON string
+     */
+    std::string serializeToString(bool pretty = false)
+    {
+        std::unique_ptr<cJSON, void (*)(cJSON *item)> json(serialize().release(), cJSON_Delete);
+        char *jsonStr = pretty ? cJSON_Print(json.get()) : cJSON_PrintUnformatted(json.get());
+        std::string result(jsonStr);
+        free(jsonStr);
+        return result;
+    }
 };
-
-#endif // ISERIALIZABLE_H


### PR DESCRIPTION
* Refactors to ISerializable abstract class method `serialize` to return a `std::unique_ptr<cJSON, void (*)(cJSON *item)>` rather than a `string`
    - This will greatly improve serialization performance for more coplex objects while also reducing complexity. Previously nexted objects might need to be serialized into strings, deserialized back into cJSON objects, and then finally added to an object that could then be serialized. This may happen several times over for sufficiently nested objects
* Adds a `serializeToString` method to `ISerializable`